### PR TITLE
Continue incomplete inference

### DIFF
--- a/acodet/front_end/st_annotate.py
+++ b/acodet/front_end/st_annotate.py
@@ -126,7 +126,10 @@ class PresetInterfaceSettings:
         self.advanced_settings()
 
     def advanced_settings(self):
-        with st.expander("# Advanced Settings"):
+        """
+        Expandable section showing advanced settings options.
+        """
+        with st.expander(r"**Advanced Settings**"):
             continue_session = self.ask_to_continue_incomplete_inference()
 
             if continue_session:

--- a/acodet/funcs.py
+++ b/acodet/funcs.py
@@ -725,9 +725,9 @@ def gen_annotations(
     audio = load_audio(file, channel)
     if audio is None:
         raise ImportError(
-            "Audio file cannot be loaded. Check if file has "
+            f"The audio file `{str(file)}` cannot be loaded. Check if file has "
             "one of the supported endings "
-            "(wav, mp3, flac, etc.))"
+            "(wav, mp3, flac, etc.)) and is not empty."
         )
     audio_batches = batch_audio(audio)
 


### PR DESCRIPTION
Add feature to allow continuing of cancelled inference sessions. Group this features and the creation of a custom folder name into an "Advanced Settings" container that is folded by default and can be expanded. 
If a session is cancelled due to disconnection from source or the process is ended its possible to continue the session. If the corresponding radio button is set to "Yes" a search for the name of the selected dataset within the "generated annotations" folder is done. If found a dropdown menu with all existing previous sessions is presented. Once chosen the session is resumed and only the last processed file is repeated and overwritten, and then continued until complete.