### PR TITLE
fixes to successfully run TorchModel

### DIFF
--- a/acodet/combine_annotations.py
+++ b/acodet/combine_annotations.py
@@ -298,11 +298,31 @@ def generate_final_annotations(
             print(f"Completed file {ind}/{len(files)}.", end="\r")
             ind += 1
 
-        # TODO include date in path by default
+        ####### use validation_files.csv to assign what's val and what's train
         save_dir = Path(conf.ANNOT_DEST).joinpath(folder)
         save_dir.mkdir(exist_ok=True, parents=True)
         df_t.to_csv(save_dir.joinpath("combined_annotations.csv"))
         df_n.to_csv(save_dir.joinpath("explicit_noise.csv"))
+        
+        # this is to ensure that we are using the same validation set
+        if True:
+            try:
+                df_t = pd.read_csv(save_dir.joinpath("combined_annotations.csv"))
+                df_n = pd.read_csv(save_dir.joinpath("explicit_noise.csv"))
+                df_t['subset'] = 'train'
+                df_n['subset'] = 'train'
+                df_val = pd.read_csv(conf.REV_ANNOT_SRC + '/validation_files.csv')
+                stems_t = np.array([Path(f).stem for f in df_t['filename']])
+                stems_n = np.array([Path(f).stem for f in df_n['filename']])
+                for file in df_val['validation_files'].values:
+                    bool_stems_t = stems_t == str(file)
+                    bool_stems_n = stems_n == str(file)
+                    df_t.loc[bool_stems_t, 'subset'] = 'val'
+                    df_n.loc[bool_stems_n, 'subset'] = 'val'
+                df_t.to_csv(save_dir.joinpath("combined_annotations.csv"))
+                df_n.to_csv(save_dir.joinpath("explicit_noise.csv"))
+            except:
+                pass
     # save_ket_annot_only_existing_paths(df)
 
 

--- a/acodet/evaluate.py
+++ b/acodet/evaluate.py
@@ -5,6 +5,7 @@ import logging
 import matplotlib.pyplot as plt
 import numpy as np
 import sklearn.metrics as metrics
+from tqdm import tqdm
 
 import torch
 import torchaudio as ta
@@ -42,11 +43,48 @@ def evaluate(train_date=False, **kwargs):
         if not Path.exists(model_path):
             logger.error(f"Model file {model_file} not found. Please check path.")
             return 1
-        checkpoint = torch.load(model_file, map_location=torch.device('cpu'))
+        checkpoint = torch.load(model_file, map_location=torch.device(conf.DEVICE))
         model.load_state_dict(checkpoint)
         figure_dir = model_path.parent.joinpath('evaluation/')
         figure_dir.mkdir(exist_ok=True)
+        model = model.eval()
         print(figure_dir)
+    elif conf.MODELCLASSNAME == 'BacpipeModel':
+        model = models.init_model()
+        model_path = Path(model_file)
+        conf.SR = model.embedder.model.sr
+        
+        # this is the case for using their own classifiers
+        if not conf.BOOL_LIN_CLFIER and conf.MODEL_NAME in ['perch_v2', 'google_whale']:
+            model.to(conf.DEVICE)
+        
+        # this is using the linear classifiers we trained
+        else:
+            
+            if not Path.exists(model_path):
+                logger.error(f"Model file {model_file} not found. Please check path.")
+                return 1
+            try:
+                checkpoint = torch.load(model_file, map_location=torch.device(conf.DEVICE))
+            except:
+                checkpoint = torch.load(model_file, weights_only=False, map_location=torch.device(conf.DEVICE))
+            try:
+                model.lin_classifier.load_state_dict(checkpoint)
+            except TypeError:
+                model.lin_classifier.load_state_dict(checkpoint())
+            model.to(conf.DEVICE)
+            lin_classifier = model.lin_classifier
+            backbone = model.embedder.model
+            model = lambda x: lin_classifier(backbone(backbone.preprocess(x)))
+        
+        # preprocessed_frames = model.model.model.preprocess(audio)
+        # new_predictions = torch.tensor(model.classify(preprocessed_frames, **kwargs))
+        
+        
+        figure_dir = model_path.parent.joinpath('evaluation/')
+        figure_dir.mkdir(exist_ok=True)
+        print(figure_dir)
+        
     elif not train_date:
         # allow user to evaluate a model that they have not trained yet
         model = models.init_model(timestamp_foldername=timestamp_foldername)
@@ -71,41 +109,58 @@ def evaluate(train_date=False, **kwargs):
 
     # create two vectors: one for true labels, and one for predicted labels
 
-    for idx, tuple in enumerate(test_data):
+    predictions = []
+    class_labels = []
+    for idx, tuple in tqdm(enumerate(test_data), 'running inference on test data', total=len(data_loader.test)):
         audio, new_labels, paths, timestamps = tuple
 
         if conf.MODELCLASSNAME == 'BacpipeModel':
-            re_audio = ta.functional.resample(
-                audio, 
-                conf.SR, 
-                model.model.model.sr
-                )
-            preprocessed_frames = model.model.model.preprocess(re_audio)
-            new_predictions = torch.tensor(model.classify(preprocessed_frames, **kwargs))
+            
+            # this is the case for using their own classifiers
+            if not conf.BOOL_LIN_CLFIER and conf.MODEL_NAME in ['perch_v2', 'google_whale']:
+                import tensorflow as tf
+                audio = tf.convert_to_tensor(audio, dtype=tf.float32)
+                embedings = model.embedder.model(audio).squeeze()
+                new_predictions = model.embedder.model.classifier_predictions(embedings)
+                if conf.MODEL_NAME == 'google_whale':
+                    new_predictions = tf.sigmoid(new_predictions)
+                    
+            else:    
+                audio = torch.tensor(audio)
+                with torch.inference_mode():
+                    new_predictions = torch.sigmoid(model(audio.to(conf.DEVICE))).squeeze()
         elif conf.MODELCLASSNAME == 'TorchModel':
-            new_predictions = model(audio).detach().cpu().squeeze()
+            with torch.inference_mode():
+                new_predictions = torch.sigmoid(model(audio)).squeeze()#.detach().cpu().squeeze()
         else:
             new_predictions = torch.tensor(model.predict(
                     tf.convert_to_tensor(audio)
                 ).squeeze())
-
-        if idx == 0:
-            predictions = new_predictions
-            class_labels = new_labels
-        else:
-            predictions = torch.hstack([
-                predictions, 
-                new_predictions
-                ])
-            class_labels = torch.hstack([class_labels, new_labels])
+        predictions.extend(new_predictions)
+        class_labels.extend(new_labels)
+        
+        # Uncomment this if you just want to try running it for a little data to 
+        # make sure the code runs.
+        if idx > 10:
+            break
+    
+    if not isinstance(predictions[0], torch.Tensor):
+        predictions = torch.tensor(np.array(predictions))
+        class_labels = np.array(class_labels)
+    else:
+        predictions = torch.hstack(predictions).to('cpu')
+        class_labels = torch.hstack(class_labels).to('cpu')
             
+    # I commented these two out cause at the moment, we are using the model's only as 
+    # feature extractors, we would need to add another option 
+    
     if conf.MODEL_NAME == 'perch_v2':
-        class_labels = model.model.model.classes
-        humpback_label_idx = np.where(np.array(class_labels)=='Megaptera novaeangliae')[0][0]
+        model_labels = np.array(model.embedder.model.classes)
+        humpback_label_idx = np.where(model_labels=='Megaptera novaeangliae')[0][0]
         predictions = predictions[:, humpback_label_idx]
     elif conf.MODEL_NAME == 'google_whale':
-        class_labels = model.model.model.classes
-        humpback_label_idx = np.where(np.array(class_labels)=='Humpback')[0][0]
+        model_labels = np.array(model.embedder.model.classes)
+        humpback_label_idx = np.where(model_labels=='Humpback')[0][0]
         predictions = predictions[:, humpback_label_idx]
 
     logger.info("All predictions collected; flattening")
@@ -133,13 +188,17 @@ def evaluate(train_date=False, **kwargs):
             f1_score = 2 * (precision[i] * recall[i]) / (precision[i] + recall[i])
             line = f"{precision[i]},{recall[i]},{t},{f1_score}\n"
             file.write(line)
+    auc_pr = metrics.auc(recall, precision)
 
     # create precision-recall curve plot
     fig, ax = plt.subplots()
-    ax.plot(recall, precision, color='tab:blue')
+    ax.plot(recall, precision, color='tab:blue', label='PR curve (area = %0.2f)' % auc_pr)
     ax.set_title('Precision-Recall Curve')
     ax.set_ylabel('Precision')
     ax.set_xlabel('Recall')
+    ax.set_xlim([0.0, 1.0])
+    ax.set_ylim([0.0, 1.05])
+    plt.legend()
 
     # save plot
     fig_filepath = Path(figure_dir).joinpath('precision_recall_curve.png')
@@ -154,7 +213,7 @@ def evaluate(train_date=False, **kwargs):
     # so use the different thresholds calculated above 
     # to mask the continuous values into class predictions
 
-    for threshold in thresholds:
+    for threshold in tqdm(np.arange(0, 1, 0.01), 'creating confusion matrices'):
         # if the predicted value is greater than the threshold,
         # give it a value of 1.0, otherwise it's 0.0
         threshold_labels = (predictions > threshold).to(torch.float)

--- a/acodet/models.py
+++ b/acodet/models.py
@@ -331,7 +331,7 @@ class BacpipeModel(nn.Module):
                 self.lin_classifier.to(device)
                 self.probe_device = device
     
-    def forward(self, x, y=None, noise=None, path=None, start=None, training=False):
+    def forward(self, x, y=None, noise=None, path=None, start=None, training=False, **kwargs):
         with torch.no_grad():
             x = self.embedder.model.preprocess(x)
             embeds = self.embedder.model(x)

--- a/acodet/torch_data.py
+++ b/acodet/torch_data.py
@@ -57,17 +57,19 @@ class AudioDataset(Dataset):
         return len(self.filepaths)
 
     def __getitem__(self, idx):
+        
+        sr = lb.get_samplerate(self.filepaths[idx])
         wave, sr = ta.load(
             self.filepaths[idx], 
-            frame_offset=self.starts[idx] * 48_000, 
-            num_frames=self.durations[idx] * 48_000
+            frame_offset=self.starts[idx] * sr, 
+            num_frames=self.durations[idx] * sr
             )
-        wave = wave.mean(dim=0).numpy()  # convert to mono if needed
+        wave = wave.mean(dim=0)  # convert to mono if needed
 
-        if sr != self.sample_rate:
+        if sr != conf.SR:
             wave = ta.functional.resample(
-                torch.tensor(wave), orig_freq=sr, new_freq=conf.SR
-            ).numpy()
+                wave, orig_freq=sr, new_freq=conf.SR
+            )
         
         # wave, sr = lb.load(
         #     path=self.filepaths[idx],

--- a/acodet/torch_data.py
+++ b/acodet/torch_data.py
@@ -6,6 +6,7 @@ import librosa as lb
 from pathlib import Path
 from acodet import global_config as conf
 import torchaudio as ta
+from multiprocessing import cpu_count
 
 np.random.seed(42)
 
@@ -75,19 +76,6 @@ class AudioDataset(Dataset):
                     raise
                 time.sleep(random.uniform(0.1, 0.5))
         
-        # sr = lb.get_samplerate(self.filepaths[idx])
-        # wave, sr = ta.load(
-        #     self.filepaths[idx], 
-        #     frame_offset=self.starts[idx] * sr, 
-        #     num_frames=self.durations[idx] * sr
-        #     )
-        # wave = wave.mean(dim=0)  # convert to mono if needed
-
-        # if sr != conf.SR:
-        #     wave = ta.functional.resample(
-        #         wave, orig_freq=sr, new_freq=conf.SR
-            # )
-        
         # wave, sr = lb.load(
         #     path=self.filepaths[idx],
         #     sr=conf.SR,
@@ -131,13 +119,13 @@ class Loader(DataLoader):
         if not 'subset' in ca_df.columns:
             files = ca_df.filename.unique()
             eval_files = files[-int(len(files) * 0.2):]
-            ca_df['subset'] = [''] * len(ca_df)
+            ca_df.loc[:, 'subset'] = [''] * len(ca_df)
             ca_df.loc[ca_df.filename.isin(eval_files), 'subset'] = 'eval'
         
         if not 'subset' in en_df.columns:
             files = en_df.filename.unique()
             eval_files = files[-int(len(files) * 0.2):]
-            en_df['subset'] = [''] * len(en_df)
+            en_df.loc[:, 'subset'] = [''] * len(en_df)
             en_df.loc[en_df.filename.isin(eval_files), 'subset'] = 'eval'
             
         df = pd.concat([ca_df, en_df], ignore_index=True)
@@ -148,8 +136,8 @@ class Loader(DataLoader):
         border = int(len(df) * 0.8)
         
         train, val = df.iloc[rand_ints[:border]], df.iloc[rand_ints[border:]]
-        train.subset = 'train'
-        val.subset = 'val'
+        train.loc[:, 'subset'] = 'train'
+        val.loc[:, 'subset'] = 'val'
         train, val = train, val
         
         df = pd.concat([train, val], ignore_index=True)
@@ -189,8 +177,8 @@ class Loader(DataLoader):
             noise_dataset,
             batch_size=conf.BATCH_SIZE,
             shuffle=True,
-            num_workers=2,
-            prefetch_factor=2,
+            num_workers=cpu_count(),
+            prefetch_factor=4,
             persistent_workers=True, 
             pin_memory=True,
             drop_last=True, # Ensure we don't get tiny batches
@@ -203,8 +191,8 @@ class Loader(DataLoader):
             batch_size=conf.BATCH_SIZE,
             shuffle=True, 
             pin_memory=True,
-            num_workers=2,
-            prefetch_factor=2,
+            num_workers=cpu_count(),
+            prefetch_factor=4,
             persistent_workers=True, 
             collate_fn=collate_fn
             )
@@ -215,8 +203,8 @@ class Loader(DataLoader):
             batch_size=conf.BATCH_SIZE,
             shuffle=False, 
             pin_memory=True,
-            num_workers=2,
-            prefetch_factor=2,
+            num_workers=cpu_count(),
+            prefetch_factor=4,
             persistent_workers=True, 
             collate_fn=collate_fn
             )
@@ -227,8 +215,8 @@ class Loader(DataLoader):
             batch_size=conf.BATCH_SIZE,
             shuffle=False, 
             pin_memory=True,
-            num_workers=2,
-            prefetch_factor=2,
+            num_workers=cpu_count(),
+            prefetch_factor=4,
             persistent_workers=True, 
             collate_fn=collate_fn
             )

--- a/acodet/torch_data.py
+++ b/acodet/torch_data.py
@@ -58,18 +58,35 @@ class AudioDataset(Dataset):
 
     def __getitem__(self, idx):
         
-        sr = lb.get_samplerate(self.filepaths[idx])
-        wave, sr = ta.load(
-            self.filepaths[idx], 
-            frame_offset=self.starts[idx] * sr, 
-            num_frames=self.durations[idx] * sr
-            )
-        wave = wave.mean(dim=0)  # convert to mono if needed
+        import time, random
 
-        if sr != conf.SR:
-            wave = ta.functional.resample(
-                wave, orig_freq=sr, new_freq=conf.SR
-            )
+        for attempt in range(3):
+            try:
+                wave, sr = lb.load(
+                    path=self.filepaths[idx],
+                    sr=conf.SR,
+                    offset=self.starts[idx],
+                    duration=self.durations[idx]
+                )
+                wave = torch.tensor(wave).squeeze()
+                break
+            except Exception:
+                if attempt == 2:
+                    raise
+                time.sleep(random.uniform(0.1, 0.5))
+        
+        # sr = lb.get_samplerate(self.filepaths[idx])
+        # wave, sr = ta.load(
+        #     self.filepaths[idx], 
+        #     frame_offset=self.starts[idx] * sr, 
+        #     num_frames=self.durations[idx] * sr
+        #     )
+        # wave = wave.mean(dim=0)  # convert to mono if needed
+
+        # if sr != conf.SR:
+        #     wave = ta.functional.resample(
+        #         wave, orig_freq=sr, new_freq=conf.SR
+            # )
         
         # wave, sr = lb.load(
         #     path=self.filepaths[idx],

--- a/acodet/torch_data.py
+++ b/acodet/torch_data.py
@@ -177,7 +177,7 @@ class Loader(DataLoader):
             noise_dataset,
             batch_size=conf.BATCH_SIZE,
             shuffle=True,
-            num_workers=cpu_count(),
+            num_workers=16,#cpu_count(),
             prefetch_factor=4,
             persistent_workers=True, 
             pin_memory=True,
@@ -191,7 +191,7 @@ class Loader(DataLoader):
             batch_size=conf.BATCH_SIZE,
             shuffle=True, 
             pin_memory=True,
-            num_workers=cpu_count(),
+            num_workers=16,#cpu_count(),
             prefetch_factor=4,
             persistent_workers=True, 
             collate_fn=collate_fn
@@ -203,7 +203,7 @@ class Loader(DataLoader):
             batch_size=conf.BATCH_SIZE,
             shuffle=False, 
             pin_memory=True,
-            num_workers=cpu_count(),
+            num_workers=16,#cpu_count(),
             prefetch_factor=4,
             persistent_workers=True, 
             collate_fn=collate_fn
@@ -215,7 +215,7 @@ class Loader(DataLoader):
             batch_size=conf.BATCH_SIZE,
             shuffle=False, 
             pin_memory=True,
-            num_workers=cpu_count(),
+            num_workers=16,#cpu_count(),
             prefetch_factor=4,
             persistent_workers=True, 
             collate_fn=collate_fn

--- a/acodet/torch_data.py
+++ b/acodet/torch_data.py
@@ -5,6 +5,7 @@ from torch.utils.data import DataLoader, Dataset
 import librosa as lb
 from pathlib import Path
 from acodet import global_config as conf
+import torchaudio as ta
 
 np.random.seed(42)
 
@@ -56,13 +57,25 @@ class AudioDataset(Dataset):
         return len(self.filepaths)
 
     def __getitem__(self, idx):
-        wave, sr = lb.load(
-            path=self.filepaths[idx],
-            sr=conf.SR,
-            offset=self.starts[idx],
-            duration=self.durations[idx]
-        )
-        wave = torch.tensor(wave).squeeze()
+        wave, sr = ta.load(
+            self.filepaths[idx], 
+            frame_offset=self.starts[idx] * 48_000, 
+            num_frames=self.durations[idx] * 48_000
+            )
+        wave = wave.mean(dim=0).numpy()  # convert to mono if needed
+
+        if sr != self.sample_rate:
+            wave = ta.functional.resample(
+                torch.tensor(wave), orig_freq=sr, new_freq=conf.SR
+            ).numpy()
+        
+        # wave, sr = lb.load(
+        #     path=self.filepaths[idx],
+        #     sr=conf.SR,
+        #     offset=self.starts[idx],
+        #     duration=self.durations[idx]
+        # )
+        # wave = torch.tensor(wave).squeeze()
 
         # Only the last frame of a long clip may be short
         if len(wave) < conf.CONTEXT_WIN:

--- a/acodet/torch_data.py
+++ b/acodet/torch_data.py
@@ -160,6 +160,8 @@ class Loader(DataLoader):
         eval_df = pd.concat([ca_df, en_df], ignore_index=True)
         eval_df = eval_df[eval_df.subset == 'eval']
         
+        rand_ints = np.random.permutation(len(eval_df))
+        eval_df = eval_df.iloc[rand_ints]
         
         # eval_df = eval_df[:20]
         self.test = AudioDataset(

--- a/acodet/torch_train.py
+++ b/acodet/torch_train.py
@@ -131,13 +131,19 @@ def train(model, data_loaders, device=None):
                 'lr': f'{current_lr:.1e}'
             })
 
+        if train_FP == 0:
+            train_FP = 0.001
+        if train_FN == 0:
+            train_FN = 0.001
         # End of Epoch Metrics
         train_loss = running_loss / train_total
         train_acc = train_correct / train_total
         train_prec = train_TP / (train_TP + train_FP)
         train_recall = train_TP / (train_TP + train_FN)
-        train_f1 = 2.0 * train_prec * train_recall / (train_prec + train_recall)
-        
+        try:
+            train_f1 = 2.0 * train_prec * train_recall / (train_prec + train_recall)
+        except ZeroDivisionError:
+            train_f1 = -1
         # 5. Validation Loop
         model.eval()
         val_correct = 0
@@ -160,6 +166,7 @@ def train(model, data_loaders, device=None):
                 labels = batch[1].to(device)
                 
                 if hasattr(model, 'probe_device'):
+                    labels = torch.tensor(labels.clone().detach(), dtype=torch.float32)
                     labels = labels.to(model.probe_device)
 
                 outputs = model(inputs)

--- a/acodet/train.py
+++ b/acodet/train.py
@@ -14,6 +14,37 @@ from acodet import global_config as conf
 
 # AUTOTUNE = tf.data.AUTOTUNE
 
+def print_train_sizes():
+    # get training set size
+    import pandas as pd
+    combined_annots = Path(conf.ANNOT_DEST) / 'combined_annotations.csv'
+    explicit_noise = Path(conf.ANNOT_DEST) / 'explicit_noise.csv'
+    
+    ca_df = pd.read_csv(combined_annots)
+    en_df = pd.read_csv(explicit_noise)
+
+    df = pd.concat([ca_df, en_df], ignore_index=True)
+    print(f'\nNumber of annotations: {int(len(df)*0.8)}') # the 0.8 is from the train/val split
+    total_train_set_size = int(len(df)*0.8) * (
+            1 + int(conf.TIME_AUGS) + int(conf.SPEC_AUG) + int(conf.MIXUP_AUGS)
+            )
+    print(
+        '\nYou are training using the augmentations: '
+        f'{conf.TIME_AUGS=}, {conf.SPEC_AUG=}, {conf.MIXUP_AUGS=}.'
+        '\nThis increases your training set to a total of: '
+        f'{total_train_set_size}')
+    total_train_steps_size = conf.BATCH_SIZE * conf.STEPS_PER_EPOCH * conf.EPOCHS
+    print(
+        '\nYour training settings are: '
+        f'{conf.BATCH_SIZE=}, {conf.STEPS_PER_EPOCH=}, {conf.EPOCHS=}.'
+        '\nThis leads to a total number of steps: ' 
+        f'{total_train_steps_size}.'
+        )
+    print(
+        '\nYour training set will be iterated through for a total of '
+        f'{total_train_steps_size / total_train_set_size:.3f} times. \n'
+          )
+    
 
 def run_training(
     ModelClassName=conf.MODELCLASSNAME,
@@ -96,6 +127,8 @@ def run_training(
         for constant in cleaned_constants:
             file.write(constant + ',' + str(getattr(conf, constant)) + '\n')
 
+    print_train_sizes()
+
     # initialize the model
     model = models.init_model(
         model_instance=ModelClassName,
@@ -111,7 +144,7 @@ def run_training(
         from acodet.plot_utils import plot_model_results, create_and_save_figure
         from acodet.tfrec import run_data_pipeline, prepare, make_spec_tensor
         from acodet.augmentation import run_augment_pipeline
-        from acodet.humpback_model_dir.leaf_pcen import FBetaScore
+        from acodet.humpback_model_dir.leaf_pcen import FBetaScore, TPositives
         import tensorflow as tf
         
         from .tf_dataloader import TFLoader
@@ -252,6 +285,7 @@ def run_training(
                     threshold=f_score_thresh,
                     name="fbeta1",
                 ),
+                TPositives(name='tpos')
             ],
         )
 

--- a/acodet/train.py
+++ b/acodet/train.py
@@ -383,7 +383,7 @@ def run_training(
         import torch
         model_file_name = model_id + '_bacpipe_lin_clfier.pt'
         torch.save(
-            model.lin_classifier.state_dict, 
+            model.lin_classifier.state_dict(), 
             model_sub_dir.joinpath(model_file_name)
             )
 


### PR DESCRIPTION
add some changes to handle stable training on server:
- [x] handle multiple cpu's loading audio segments, this caused problems, now we're just giving them some retry chances, which fixed it for my end
- [x] include number of parallel workers - this way audio loading is optimized so that you can use all available cpu cores. I ended up limiting it to 16 because the SLURM system my server is running was complaining that I'm too greedy.
- [x] add print statement on training start telling you exactly how much data you have and how many times you'll iterate through it all if you run all epochs.